### PR TITLE
Extended eval selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,4 +260,78 @@ image_list = hdf_image(files, index=0)
 data_list = hdf_eval(files, 'signal / Transmission')
 ```
 
+### Metadata Evaluation 
+Functionality for namespace evaluation of the hdf file allows for a number of rules allowing easy extraction
+of formatted metadata. The Evaluation functions are:
 
+ - `HdfMap.eval(hdfobj, 'name')` -> value
+ - `HdfMap.format_hdf(hdfobj, '{name}')` -> string
+ - `HdfLoader('eval')` -> value
+ - `HdfLoader.eval('eval')` -> value
+ - `HdfLoader.format('{name}')` -> string
+ - `hdf_eval([files], 'name')` -> list[values]
+ - `hdf_format([files], '{name}')` -> list[string]
+
+#### eval vs format
+Evaluation functions evaluate the expression as given, replacing names in the hdfmap namespace with their associated
+values, or using the rules below. The format functions allow the input of python 
+[f-strings](https://docs.python.org/3/tutorial/inputoutput.html#fancier-output-formatting),
+allowing precise formatting to be applied and returning a string.
+
+#### Rules
+The following patterns are allowed in any expression:
+ - 'filename': str, name of hdf_file
+ - 'filepath': str, full path of hdf_file
+ - '_*name*': str hdf path of *name*
+ - '__*name*': str internal name of *name* (e.g. for 'axes')
+ - 's_*name*': string representation of dataset (includes units if available)
+ - '*name*@attr': returns attribute of dataset *name*
+ - '*name*?(default)': returns default if *name* doesn't exist
+ - '(name1|name2|name3)': returns the first available of the names
+ - '(name1|name2@(default))': returns the first available name or default
+
+#### Examples
+```python
+from hdfmap import create_nexus_map, load_hdf
+
+# HdfMap from NeXus file:
+hmap = create_nexus_map('file.nxs')
+with load_hdf('file.nxs') as nxs:
+    # mathematical array expressions (using np as Numpy)
+    data = hmap.eval(nxs, 'int(np.max(total / Transmission / count_time))')
+    # return the path of a name
+    path = hmap.eval(nxs, '_axes')  # -> '/entry/measurement/h'
+    # return the real name of a variable
+    name = hmap.eval(nxs, '__axes')  # -> 'h'
+    # return label, using dataset attributes
+    label = hmap.eval(nxs, 's_ppy')  # example uses @decimals and @units
+    # return dataset attributes
+    attr = hmap.eval(nxs, 'idgap@units')  # -> 'mm'
+    # return first available dataset
+    cmd = hmap.eval(nxs, '(cmd|title|scan_command)')  # -> 'scan hkl ...'
+    # return first available or default value
+    atten = hmap.eval(nxs, '(gains_atten|atten?(0))')  # -> 0
+    # python expression using multiple parameters
+    pol = hmap.eval(nxs, '"pol in" if abs(delta_offset) < 0.1 and abs(thp) > 20 else "pol out"')
+    # formatted strings
+    title = hmap.format_hdf(nxs, '{filename}: {scan_command}')
+    hkl = hmap.format_hdf(nxs, '({np.mean(h):.3g},{np.mean(k):.3g},{np.mean(l):.3g})')
+
+# Or, using NexusLoader:
+from hdfmap import NexusLoader
+
+scan = NexusLoader('file.nxs')
+# normalised default-signal
+print(scan('signal / count_time / Transmission / (rc / 300.)'))
+# axes label
+print(scan.format('{__axes} [{axes@units}]'))
+
+# Or, for multiple-files:
+from hdfmap import hdf_eval, hdf_format, list_files
+
+files = [f"file{n}.nxs" for n in range(10)]
+
+energy_values = hdf_eval(files, '(en|energy@(8))')
+list_scans = hdf_format(files, '{filename}: ({np.mean(h):.3g},{np.mean(k):.3g},{np.mean(l):.3g}) : {scan_command})')
+print('\n'.join(list_scans))
+```

--- a/examples/example_metadata.py
+++ b/examples/example_metadata.py
@@ -1,0 +1,49 @@
+"""
+hdfmap example
+
+Generate metadata using namespace expressions
+
+By Dan Porter
+27/11/2024 (hdfmap v0.6.2)
+"""
+
+import hdfmap
+
+print(hdfmap.version_info())
+
+VALUES = {
+    'cmd': '(cmd|scan_command)',
+    'date': 'start_time',
+    'pol': 'polarisation?("lh")',
+    'iddgap': 'iddgap',
+    'rowphase': 'idutrp if iddgap == 100 else iddtrp',
+    'endstation': 'instrument_name',
+    'temp': '(T_sample|lakeshore336_sample?(300))',
+    'rot': '(scmth|xabs_theta|ddiff_theta?(0))',
+    'field': 'field_x?(0), field_y?(0), field_z?(0)',
+    'energy': '(fastEnergy|pgm_energy|energy)',
+    'monitor': '(C2|ca62sr)',
+    'tey': '(C1|ca61sr)', # / (C2|ca62sr)',
+    'tfy': '(C3|ca63sr)', # / (C2|ca62sr)',
+}
+
+LABELS = {
+    'name': '{filename}: {scan_command}',
+    'temp': 'T = {(T_sample|lakeshore336_sample@(300)):.2f}',
+    'energy': 'E = {np.mean((fastEnergy|pgm_energy|energy@(0))):.2f} eV',
+}
+
+if __name__ == '__main__':
+    filename = '../tests/data/i06-353130.nxs'
+
+    m = hdfmap.create_nexus_map(filename)
+    with m.load_hdf() as nxs:
+        values = {name: m.eval(nxs, expr) for name, expr in VALUES.items()}
+        labels = {name: m.format_hdf(nxs, expr) for name, expr in LABELS.items()}
+
+    print('Values:')
+    print('\n'.join(f"{name:20}: {value}" for name, value in values.items()))
+    print('\n\nLabels:')
+    print('\n'.join(f"{name:20}: {value}" for name, value in labels.items()))
+
+    print('\n\nFinished!')

--- a/examples/example_metadata.py
+++ b/examples/example_metadata.py
@@ -23,18 +23,20 @@ VALUES = {
     'field': 'field_x?(0), field_y?(0), field_z?(0)',
     'energy': '(fastEnergy|pgm_energy|energy)',
     'monitor': '(C2|ca62sr)',
-    'tey': '(C1|ca61sr)', # / (C2|ca62sr)',
-    'tfy': '(C3|ca63sr)', # / (C2|ca62sr)',
+    'tey': '(C1|ca61sr)',
+    'tfy': '(C3|ca63sr)',
 }
 
 LABELS = {
     'name': '{filename}: {scan_command}',
-    'temp': 'T = {(T_sample|lakeshore336_sample@(300)):.2f}',
-    'energy': 'E = {np.mean((fastEnergy|pgm_energy|energy@(0))):.2f} eV',
+    'temp': 'T = {(T_sample|lakeshore336_sample?(300)):.2f} K',
+    'field': 'B = {np.sqrt(np.sum(np.square([field_x?(0), field_y?(0), field_z?(0)]))):.2f} T',
+    'energy': 'E = {np.mean((fastEnergy|pgm_energy|energy?(0))):.2f} eV',
 }
 
 if __name__ == '__main__':
     filename = '../tests/data/i06-353130.nxs'
+    # filename = '/dls/science/groups/das/ExampleData/hdfmap_tests/i06/i06-1-302762.nxs'
 
     m = hdfmap.create_nexus_map(filename)
     with m.load_hdf() as nxs:

--- a/src/hdfmap/__init__.py
+++ b/src/hdfmap/__init__.py
@@ -65,8 +65,8 @@ __all__ = [
     'set_all_logging_level', 'version_info', 'module_info'
 ]
 
-__version__ = "0.6.1"
-__date__ = "2024/11/13"
+__version__ = "0.6.2"
+__date__ = "2024/11/26"
 
 
 def version_info() -> str:

--- a/src/hdfmap/__init__.py
+++ b/src/hdfmap/__init__.py
@@ -66,7 +66,7 @@ __all__ = [
 ]
 
 __version__ = "0.6.2"
-__date__ = "2024/11/26"
+__date__ = "2024/11/27"
 
 
 def version_info() -> str:

--- a/src/hdfmap/file_functions.py
+++ b/src/hdfmap/file_functions.py
@@ -96,12 +96,13 @@ def hdf_data(filenames: str | list[str], name_or_path: str | list[str], hdf_map:
     return out
 
 
-def hdf_eval(filenames: str | list[str], expression: str, hdf_map: HdfMap = None, fixed_output=False):
+def hdf_eval(filenames: str | list[str], expression: str, hdf_map: HdfMap = None, default=None, fixed_output=False):
     """
     Evaluate expression using dataset names
     :param filenames: str or list of str - file paths
     :param expression: str expression to evaluate in each file, e.g. "roi2_sum / Transmission"
     :param hdf_map: HdfMap object, or None to generate from first file
+    :param default: value to give if dataset doesn't exist in file
     :param fixed_output: if True, always returns list len(filenames)
     :return if single file: single output
     :return if multi file: list, len(filenames)
@@ -115,18 +116,19 @@ def hdf_eval(filenames: str | list[str], expression: str, hdf_map: HdfMap = None
     for filename in filenames:
         logger.info(f"\nHDF file: {filename}")
         with load_hdf(filename) as hdf:
-            out.append(hdf_map.eval(hdf, expression))
+            out.append(hdf_map.eval(hdf, expression, default=default))
     if not fixed_output and len(filenames) == 1:
         return out[0]
     return out
 
 
-def hdf_format(filenames: str | list[str], expression: str, hdf_map: HdfMap = None, fixed_output=False):
+def hdf_format(filenames: str | list[str], expression: str, hdf_map: HdfMap = None, default=None, fixed_output=False):
     """
     Evaluate string format expression using dataset names
     :param filenames: str or list of str - file paths
     :param expression: str expression to evaluate in each file, e.g. "the energy is {en:.2f} keV"
     :param hdf_map: HdfMap object, or None to generate from first file
+    :param default: value to give if dataset doesn't exist in file
     :param fixed_output: if True, always returns list len(filenames)
     :return if single file: single output
     :return if multi file: list, len(filenames)
@@ -140,7 +142,7 @@ def hdf_format(filenames: str | list[str], expression: str, hdf_map: HdfMap = No
     for filename in filenames:
         logger.info(f"\nHDF file: {filename}")
         with load_hdf(filename) as hdf:
-            out.append(hdf_map.format_hdf(hdf, expression))
+            out.append(hdf_map.format_hdf(hdf, expression, default=default))
     if not fixed_output and len(filenames) == 1:
         return out[0]
     return out

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -42,9 +42,23 @@ def test_nexus_eval(hdf_map):
         assert out == 70, "Expression output gives wrong result"
         path = hdf_map.eval(hdf, '_axes')
         assert path == '/entry/measurement/h', "Wrong axes path"
+        out = hdf_map.eval(hdf, '__axes')
+        assert out == 'h', "Wrong axes name"
+        out = hdf_map.eval(hdf, 's_ppy')  # example uses decimals and units
+        assert out == '-7.4871 mm', "Incorrect label"
+        out = hdf_map.eval(hdf, 'idgap@units')
+        assert out == 'mm', "Incorrect attribute"
+        out = hdf_map.eval(hdf, '(cmd|nout|scan_command)')
+        assert out == 'scan hkl [0.97, 0.022, 0.112] [0.97, 0.022, 0.132] [0, 0, 0.001] MapperProc pil3_100k 1'
+        out = hdf_map.eval(hdf, '(gains_atten|atten?(0))')
+        assert out == 0, "default expression failed"
+        out = hdf_map.eval(hdf, '"pol in" if abs(delta_offset) < 0.1 and abs(thp) > 20 else "pol out"')
+        assert out == 'pol out', "expression failed"
         title = hdf_map.format_hdf(hdf, '{filename}: {scan_command}')
         correct = '1040323.nxs: scan hkl [0.97, 0.022, 0.112] [0.97, 0.022, 0.132] [0, 0, 0.001] MapperProc pil3_100k 1'
         assert title == correct, "Expression output gives wrong result"
+        out = hdf_map.format_hdf(hdf, '({np.mean(h):.3g},{np.mean(k):.3g},{np.mean(l):.3g})')
+        assert out == '(0.97,0.0221,0.122)', "Expression output gives wrong result"
 
 
 def test_3d_scan(hdf_map):


### PR DESCRIPTION
added extended eval commands allowing defaults and alternate names.

changes to eval_functions.py:
 - added syntax 'name?(default)'
 - added syntax 'name1|name2|name3'

Updated help strings and documentation.

Added tests, all tests pass.

Added example_metadata.py