### PR TITLE
Add ast interpreter option

### DIFF
--- a/docs/usage/examples.md
+++ b/docs/usage/examples.md
@@ -118,6 +118,33 @@ roi_sum = m('d_IMAGE[..., 90:110, 200:240].sum(axis=(-1, -2))') # -> array with 
 Note: External datasets are currently not closed by context managers (i.e. `with h5py.File...`). 
 This behaviour is a [known bug](https://github.com/h5py/h5py/issues/2454) and may be fixed in the future.
 
+### New in V1.0.1: Custom ROIs
+User defined Regions of Interest (ROIs) can be assigned for image datasets. The ROIs will only
+be evaluated when read and will only read the required region - not the whole dataset.
+
+On defining a ROI, several names will be added to the namespace:
+ - *name* -> returns the whole ROI array as a HDF5 dataset
+ - *name*_total -> returns the sum of each image in the ROI array
+ - *name*_max -> returns the max of each image in the ROI array
+ - *name*_min -> returns the min of each image in the ROI array
+ - *name*_mean -> returns the mean of each image in the ROI array
+ - *name*_bkg -> returns the background ROI array (area around ROI)
+ - *name*_rmbkg -> returns the total with background subtracted
+ - *name*_box -> returns the pixel positions of the ROI
+ - *name*_bkg_box -> returns the pixel positions of the background ROI
+
+Each ROI is given a name and must have a centre and widths defined. The centre value can be a string expression,
+allowing you to call other values from the file, such as a defined detector centre.
+
+```python
+from hdfmap import create_nexus_map
+
+m = create_nexus_map('file.nxs')
+m.add_roi('my_roi1', 'pil3_centre_j', 'pil3_centre_i', 31, 21)
+roi_volume = m('my_roi1')  # shape: (n, 31, 21)
+roi_total = m('my_roi1_total')  # shape: (n, )
+```
+
 
 ### formatted strings from metadata
 Format strings can also be parsed to obtain data from the hdf files. 

--- a/examples/example_rois.py
+++ b/examples/example_rois.py
@@ -1,0 +1,55 @@
+"""
+HdfMap Example - Define Regions of Interest
+
+Requires HdfMap V1.0.1
+"""
+
+import hdfmap
+import numpy as np
+import matplotlib.pyplot as plt
+
+if __name__ == '__main__':
+    filename = '../tests/data/1049598.nxs'
+
+    m = hdfmap.create_nexus_map(filename)
+    # Nexus file contains datasets 'pil3_centre_j' defining the detector centre
+    cen_i = 'pil3_centre_j'
+    cen_j = 'pil3_centre_i'
+    cen_j2 = 'pil3_centre_i-50'
+    wid_i = 61
+    wid_j = 21
+    m.add_roi('my_roi1', cen_i, cen_j, wid_i, wid_j)
+    m.add_roi('my_roi2', cen_i, cen_j2, wid_i, wid_j)
+    with m.load_hdf() as nxs:
+        ij_box1 = m.eval(nxs, 'my_roi1_box')
+        ij_box2 = m.eval(nxs, 'my_roi2_box')
+        roi1 = m.eval(nxs, 'my_roi1')
+        roi2 = m.eval(nxs, 'my_roi2')
+        roi1_total = m.eval(nxs, 'my_roi1_total')
+        roi2_total = m.eval(nxs, 'my_roi2_total')
+        total = m.eval(nxs, 'total')
+        idx1 = np.argmax(roi1_total)
+        idx2 = np.argmax(roi2_total)
+        image1 = m.get_image(nxs, idx1)
+        image2 = m.get_image(nxs, idx2)
+
+    # Plot the ROIs
+    fig, axes = plt.subplots(3, 1, figsize=(6, 8), dpi=100)
+    fig.subplots_adjust(top=0.93, bottom=0.08)
+    axes[0].imshow(image1)
+    axes[0].plot(ij_box1[:, 1], ij_box1[:, 0], 'k-', lw=2, label='roi1')
+    axes[0].plot(ij_box2[:, 1], ij_box2[:, 0], 'w-', lw=2, label='roi2')
+    axes[0].legend()
+    axes[0].set_title(f"index = {idx1}")
+    axes[1].imshow(image2)
+    axes[1].plot(ij_box1[:, 1], ij_box1[:, 0], 'k-', lw=2, label='roi1')
+    axes[1].plot(ij_box2[:, 1], ij_box2[:, 0], 'w-', lw=2, label='roi2')
+    axes[1].legend()
+    axes[1].set_title(f"index = {idx2}")
+    axes[2].plot(total, label='total')
+    axes[2].plot(roi1_total, label='roi1 total')
+    axes[2].plot(roi2_total, label='roi2 total')
+    axes[2].legend()
+
+    plt.show()
+

--- a/src/hdfmap/__init__.py
+++ b/src/hdfmap/__init__.py
@@ -65,8 +65,8 @@ __all__ = [
     'set_all_logging_level', 'version_info', 'module_info'
 ]
 
-__version__ = "1.0.0"
-__date__ = "2025/07/23"
+__version__ = "1.0.1"
+__date__ = "2025/09/02"
 
 
 def version_info() -> str:

--- a/src/hdfmap/hdfmap_class.py
+++ b/src/hdfmap/hdfmap_class.py
@@ -368,6 +368,8 @@ class HdfMap:
             *name*_mean -> returns the mean of each image in the ROI array
             *name*_bkg -> returns the background ROI array (area around ROI)
             *name*_rmbkg -> returns the total with background subtracted
+            *name*_box -> returns the pixel positions of the ROI
+            *name*_bkg_box -> returns the pixel positions of the background ROI
 
         :param name: string name of the ROI
         :param cen_i: central pixel index along first dimension, can be callable string
@@ -386,6 +388,15 @@ class HdfMap:
         roi_max = f"{roi_array}.max(axis=(-1, -2))"
         roi_min = f"{roi_array}.min(axis=(-1, -2))"
         roi_mean = f"{roi_array}.mean(axis=(-1, -2))"
+        roi_box = (
+            'array([' +
+            f"[{cen_i}-{wid_i:.0f}, {cen_j}-{wid_j:.0f}]," +
+            f"[{cen_i}-{wid_i:.0f}, {cen_j}+{wid_j:.0f}]," +
+            f"[{cen_i}+{wid_i:.0f}, {cen_j}+{wid_j:.0f}]," +
+            f"[{cen_i}+{wid_i:.0f}, {cen_j}-{wid_j:.0f}]," +
+            f"[{cen_i}-{wid_i:.0f}, {cen_j}-{wid_j:.0f}]," +
+            '])'
+        )
 
         islice = f"{cen_i}-{wid_i * 2:.0f} : {cen_i}+{wid_i * 2:.0f}"
         jslice = f"{cen_j}-{wid_j * 2:.0f} : {cen_j}+{wid_j * 2:.0f}"
@@ -395,6 +406,16 @@ class HdfMap:
         roi_bkg_mean = f"{roi_bkg_total}/(12*{wid_i * wid_j})"
         # Transpose array to broadcast bkg_total
         roi_rmbkg = f"({roi_array}.T - {roi_bkg_mean}).sum(axis=(0, 1))"
+        roi_bkg_box = (
+            'array([' +
+            f"[{cen_i}-{wid_i * 2:.0f}, {cen_j}-{wid_j * 2:.0f}]," +
+            f"[{cen_i}-{wid_i * 2:.0f}, {cen_j}+{wid_j * 2:.0f}]," +
+            f"[{cen_i}+{wid_i * 2:.0f}, {cen_j}+{wid_j * 2:.0f}]," +
+            f"[{cen_i}+{wid_i * 2:.0f}, {cen_j}-{wid_j * 2:.0f}]," +
+            f"[{cen_i}-{wid_i * 2:.0f}, {cen_j}-{wid_j * 2:.0f}]," +
+            '])'
+        )
+
         alternate_names = {
             f"{name}_total": roi_total,
             f"{name}_max": roi_max,
@@ -402,6 +423,8 @@ class HdfMap:
             f"{name}_mean": roi_mean,
             f"{name}_bkg": roi_bkg_total,
             f"{name}_rmbkg": roi_rmbkg,
+            f"{name}_box": roi_box,
+            f"{name}_bkg_box": roi_bkg_box,
             name: roi_array,
         }
         self.add_named_expression(**alternate_names)

--- a/src/hdfmap/hdfmap_class.py
+++ b/src/hdfmap/hdfmap_class.py
@@ -10,7 +10,7 @@ import h5py
 
 from . import load_hdf
 from .logging import create_logger
-from .eval_functions import (expression_safe_name, extra_hdf_data, eval_hdf,
+from .eval_functions import (expression_safe_name, extra_hdf_data, eval_hdf, HdfMapInterpreter,
                              format_hdf, dataset2data, dataset2str, is_image,
                              DEFAULT, SEP, generate_identifier, build_hdf_path)
 
@@ -902,6 +902,23 @@ class HdfMap:
         :return: eval_hdf(f"expression")
         """
         return format_hdf(hdf_file, expression, self.combined, self._local_data, self._alternate_names, default, raise_errors)
+
+    def create_interpreter(self, default=DEFAULT):
+        """
+        Create an interpreter object for the current file
+        The interpreter is a sub-class of asteval.Interpreter that parses expressions for hdfmap eval patters
+        and loads data when required.
+
+        The hdf file self.filename is used to extract data and is only opened during evaluation.
+        """
+        interpreter = HdfMapInterpreter(
+            hdfmap=self,
+            replace_names=self._alternate_names,
+            default=default,
+            user_symbols=self._local_data,
+            use_numpy=True
+        )
+        return interpreter
 
     def create_dataset_summary(self, hdf_file: h5py.File) -> str:
         """Create summary of all datasets in file"""

--- a/tests/test_hdfmap_class.py
+++ b/tests/test_hdfmap_class.py
@@ -1,3 +1,4 @@
+import h5py
 import pytest
 import sys
 import os
@@ -237,3 +238,27 @@ def test_eval_named_expression(hdf_map):
         out = hdf_map.eval(hdf, 'my_path')
         assert abs(out - 3.58) < 0.001, "Expression output gives wrong result"
 
+
+def test_roi(hdf_map):
+    hdf_map.add_roi('nroi1', 'pil3_centre_j', 'pil3_centre_i', 101, 21)
+    with hdfmap.load_hdf(FILE_HKL) as hdf:
+        out = hdf_map.eval(hdf, 'nroi1')
+        assert out.shape == (101, 100, 20), "ROI output is wrong shape"
+        out = hdf_map.eval(hdf, 'max(nroi1_total)')
+        assert out == 199042, "ROI total gives wrong result"
+        out = hdf_map.eval(hdf, 'max(nroi1_max)')
+        assert out == 13191, "ROI max gives wrong result"
+        out = hdf_map.eval(hdf, 'max(nroi1_min)')
+        assert out == 0, "ROI min gives wrong result"
+        out = hdf_map.eval(hdf, 'max(nroi1_mean)')
+        assert abs(out - 99.521) < 0.001, "ROI mean gives wrong result"
+        out = hdf_map.eval(hdf, 'max(nroi1_bkg)')
+        assert out == 333259, "ROI bkg gives wrong result"
+        out = hdf_map.eval(hdf, 'max(nroi1_rmbkg)')
+        assert abs(out - 195839) < 0.001, "ROI rmbkg gives wrong result"
+
+
+def test_interpreter(hdf_map):
+    ii = hdf_map.create_interpreter()
+    assert abs(ii('abs(mean(max(roi2_sum)))') - 359573) < 0.001, "Expression output gives wrong result"
+    assert 'hkl' in ii('scan_command'), 'Expression output gives wrong result'


### PR DESCRIPTION
add new functionality to HdfMap object:
 - `ii = HdfMap.create_interpreter()` - create interpreter object that will evaluate strings and load data
 - `HdfMap.add_roi(...)` - wrapper to easily add region of interest to named expressions.

### eval_functions.py
 - refactor eval functions and create prepare_expression_load_data()
 - add class HdfMapInterpreter

### hdfmap_class.py
 - add interpreter method
 - add method add_roi() to convieniently add expressions to the named_expression table.
 - other minor changes