### PR TITLE
Add use_stored_data method

### DIFF
--- a/docs/usage/examples.md
+++ b/docs/usage/examples.md
@@ -70,6 +70,8 @@ The seconds step evaluates the modified expression in the data namespace.
 Additional variables can be assigned to the local namespace accessed during eval or format, either directly accessing
 data, or as shorthand for a path or expression.
 
+**Note V1.0.2**: local variables will be overwritten by values from files, unless use_local_data() is set.   
+
 ```python
 from hdfmap import NexusLoader
 
@@ -88,6 +90,23 @@ expr = {
 }
 scan.map.add_named_expression(**expr)
 ydata = scan.eval('signal/normby')
+```
+
+#### New in V1.0.2: reload data from local namespace
+When datasets are read using hdfmap.eval or similar, the data is stored with local data. This data can be accessed 
+rapidly by turning the option on. This is particuarly useful when having to reload large datasets over a slow 
+network connection, but should not be used if reading from multiple files using the same hdfmap object.
+
+```python
+from hdfmap import NexusLoader
+
+scan = NexusLoader('file.nxs')
+scan.map.use_local_data()
+
+volume = scan.eval('IMAGE')  # loads the entire image volume, which can be slow
+norm_vol = scan.eval('IMAGE / Transmission')  # repeated call is much faster because IMAGE was already in memory
+
+scan.map.use_local_data(False)  # return to the default behaviour
 ```
 
 #### New in V1.0.0: load datasets

--- a/src/hdfmap/__init__.py
+++ b/src/hdfmap/__init__.py
@@ -66,7 +66,7 @@ __all__ = [
 ]
 
 __version__ = "1.0.2"
-__date__ = "2025/09/25"
+__date__ = "2025/10/14"
 
 
 def version_info() -> str:

--- a/tests/test_hdf_loader.py
+++ b/tests/test_hdf_loader.py
@@ -52,8 +52,9 @@ def test_hdf_tree_dict():
 
 def test_hdf_compare():
     comparison = hdfmap.hdf_compare(FILE_HKL, FILE_NEW_NEXUS)
-    print(comparison)
-    assert len(comparison) == 26879, "comparison string wrong length"
+    # Remove file paths for comparison
+    comparison = '\n'.join(comparison.splitlines()[4:])
+    assert len(comparison) == 26745, "comparison string wrong length"
 
 
 def test_hdf_find():

--- a/tests/test_hdfmap_class.py
+++ b/tests/test_hdfmap_class.py
@@ -145,9 +145,9 @@ def test_create_metadata_list(hdf_map):
     # remove first line to avoid filepath errors
     meta = '\n'.join(meta.splitlines()[1:])
     if sys.version_info >= (3, 11, 0):
-        assert len(meta) == 5182, "Length of metadata list wrong"
-    else:  # length of time strings changes
         assert len(meta) == 5214, "Length of metadata list wrong"
+    else:  # length of time strings changes
+        assert len(meta) == 5182, "Length of metadata list wrong"
 
 
 def test_get_scannables(hdf_map):

--- a/tests/test_hdfmap_class.py
+++ b/tests/test_hdfmap_class.py
@@ -219,11 +219,11 @@ def test_format_hdf(hdf_map):
 
 
 def test_eval_local_data(hdf_map):
-    hdf_map.add_local(new_var='testing-testing', Transmission=10.)
+    hdf_map.add_local(new_var='testing-testing', myTransmission=10.)
     with hdfmap.load_hdf(FILE_HKL) as hdf:
         out = hdf_map.eval(hdf, 'new_var')
         assert out == 'testing-testing', "Expression output gives wrong result"
-        out = hdf_map.eval(hdf, 'int(max(sum / Transmission / count_time))')
+        out = hdf_map.eval(hdf, 'int(max(sum / myTransmission / count_time))')
         assert out == 653318, "Expression output gives wrong result"
 
 

--- a/tests/test_hdfmap_class.py
+++ b/tests/test_hdfmap_class.py
@@ -142,10 +142,12 @@ def test_get_metadata(hdf_map):
 def test_create_metadata_list(hdf_map):
     with hdfmap.hdf_loader.load_hdf(FILE_HKL) as hdf:
         meta = hdf_map.create_metadata_list(hdf)
+    # remove first line to avoid filepath errors
+    meta = '\n'.join(meta.splitlines()[1:])
     if sys.version_info >= (3, 11, 0):
-        assert len(meta) == 5280, "Length of metadata list wrong"
+        assert len(meta) == 5182, "Length of metadata list wrong"
     else:  # length of time strings changes
-        assert len(meta) == 5312, "Length of metadata list wrong"
+        assert len(meta) == 5214, "Length of metadata list wrong"
 
 
 def test_get_scannables(hdf_map):

--- a/tests/test_many_files.py
+++ b/tests/test_many_files.py
@@ -11,6 +11,22 @@ NFILES = 1332  # number of files to test (max 1332)
 # FORMAT_STRING = """#{entry_identifier}\ncmd: {scan_command}\n"""
 FORMAT_STRING = '#{entry_identifier}: {start_time} : E={incident_energy:.3f} keV : {scan_command}'
 
+DATA_FOLDER = os.path.join(os.path.dirname(__file__), 'data')
+LOCAL_FILES = [
+    DATA_FOLDER + '/1040323.nxs',  # new nexus format
+    DATA_FOLDER + '/i06-353130.nxs',  # new nexus format
+]
+
+
+def test_use_local_data():
+    m = hdfmap.create_nexus_map(LOCAL_FILES[0])
+    exp = "(cmd|scan_command)"
+    cmd = [m.eval(hdfmap.load_hdf(f), exp) for f in LOCAL_FILES]
+    assert len(set(cmd)) > 1, "datasets from different files are the same when they shouldn't be"
+    m.use_local_data(True)
+    cmd = [m.eval(hdfmap.load_hdf(f), exp) for f in LOCAL_FILES]
+    assert len(set(cmd)) == 1, "datasets from different files are different when they shouldn't be"
+
 
 @only_dls_file_system
 def test_compare_time_for_many_files():


### PR DESCRIPTION

Option to turn on and off local data loading in hdfmap.

* Fix for #33 

### eval_functions.py
 - Add option use_stored_data to prepare_expression_load_data()
 - populate data_namspace in generate_namespace(), don't populate defaults.
 - load data from file based on identifiers. Remove identifiers if they are in data_namespace and use_stored_data is true.
 - propagate option to eval and format_hdf

### hdfmap_class.py
 - propagate option to eval and format_hdf
 - add _use_local_data parameter
 - add use_local_data function

### test_many_files.py
 - add test to check that this works in both scenarios.

### tests
 - all tests pass.
 - updated some tests so they are note comparing absolute file paths.