### PR TITLE
42 multiple instances of hdfloader contain the same local namespace

### DIFF
--- a/src/hdfmap/__init__.py
+++ b/src/hdfmap/__init__.py
@@ -66,8 +66,8 @@ __all__ = [
     'set_all_logging_level', 'version_info', 'module_info'
 ]
 
-__version__ = "1.1.1"
-__date__ = "2025/11/18"
+__version__ = "1.2.0"
+__date__ = "2026/04/02"
 __author__ = "Dan Porter"
 
 

--- a/src/hdfmap/eval_functions.py
+++ b/src/hdfmap/eval_functions.py
@@ -212,20 +212,6 @@ def find_identifiers(expression: str) -> list[str]:
     return [name for name in asteval.get_ast_names(ast.parse(expression))]
 
 
-class _NameReplacer(ast.NodeTransformer):
-    """NodeTransformer to replace variable names using a mapping"""
-    def __init__(self, var_mapping: dict[str, str]):
-        self.mapping = var_mapping
-
-    def visit_Name(self, node: ast.Name) -> ast.Name:
-        if node.id in self.mapping:
-            return ast.copy_location(
-                ast.Name(id=self.mapping[node.id], ctx=node.ctx),
-                node
-            )
-        return node
-
-
 def replace_expression_vars(expr: str, mapping: dict[str, str]) -> str:
     """
     Replace variable names in an expression
@@ -236,9 +222,10 @@ def replace_expression_vars(expr: str, mapping: dict[str, str]) -> str:
     :param mapping: mapping from variable names to replacements
     :return: replaced expression
     """
-    tree = ast.parse(expr, mode='eval')
-    new_tree = _NameReplacer(mapping).visit(tree)
-    return ast.unparse(new_tree)
+    for name, repl in mapping.items():
+        pattern = r'\b' + re.escape(name) + r'\b'
+        expr = re.sub(pattern, repl, expr)
+    return expr
 
 
 def extra_hdf_data(hdf_file: h5py.File) -> dict:

--- a/src/hdfmap/eval_functions.py
+++ b/src/hdfmap/eval_functions.py
@@ -377,7 +377,8 @@ def prepare_expression_load_data(hdf_file: h5py.File, expression: str, hdf_names
     if use_stored_data:
         # remove identifiers already in data_namespace so they aren't reloaded
         identifiers = [new_id for new_id in identifiers if new_id not in data_namespace]
-    generate_namespace(hdf_file, hdf_namespace, identifiers, default, data_namespace)  # load data into data_namespace
+    # load identifiers data from file into data_namespace
+    generate_namespace(hdf_file, hdf_namespace, identifiers, default, data_namespace)
     logger.info(f"Expression: {expression}\nidentifiers: {identifiers}\n")
     logger.debug(f"hdf data namespace: {data_namespace}\n")
     return expression

--- a/src/hdfmap/eval_functions.py
+++ b/src/hdfmap/eval_functions.py
@@ -212,6 +212,35 @@ def find_identifiers(expression: str) -> list[str]:
     return [name for name in asteval.get_ast_names(ast.parse(expression))]
 
 
+class _NameReplacer(ast.NodeTransformer):
+    """NodeTransformer to replace variable names using a mapping"""
+    def __init__(self, var_mapping: dict[str, str]):
+        self.mapping = var_mapping
+
+    def visit_Name(self, node: ast.Name) -> ast.Name:
+        if node.id in self.mapping:
+            return ast.copy_location(
+                ast.Name(id=self.mapping[node.id], ctx=node.ctx),
+                node
+            )
+        return node
+
+
+def replace_expression_vars(expr: str, mapping: dict[str, str]) -> str:
+    """
+    Replace variable names in an expression
+
+        'x + y' = replace_expression_vars('a + b', {'a': 'x', 'b': 'y'})
+
+    :param expr: expression to replace variable names
+    :param mapping: mapping from variable names to replacements
+    :return: replaced expression
+    """
+    tree = ast.parse(expr, mode='eval')
+    new_tree = _NameReplacer(mapping).visit(tree)
+    return ast.unparse(new_tree)
+
+
 def extra_hdf_data(hdf_file: h5py.File) -> dict:
     """Extract filename, filepath and other additional data fom hdf file"""
     filepath = getattr(hdf_file, 'filename', 'unknown')
@@ -275,7 +304,7 @@ def generate_namespace(hdf_file: h5py.File, hdf_namespace: dict[str, str],
 
 
 def prepare_expression(hdf_file: h5py.File, expression: str, hdf_namespace: dict[str, str],
-                       data_namespace: dict[str, typing.Any] | None) -> str:
+                       data_namespace: dict[str, typing.Any] | None, replace_names: dict[str, str]) -> str:
     """
     Prepare an expression for evaluation using the namespace of the hdf file
     Returns the modified expression replacing attribute names and alternates with
@@ -301,8 +330,12 @@ def prepare_expression(hdf_file: h5py.File, expression: str, hdf_namespace: dict
     :param expression: str expression to be evaluated
     :param hdf_namespace: dict of {'variable name': '/hdf/dataset/path'}
     :param data_namespace: dict of {'variable name': value} ** note: values will be added to this dict
+    :param replace_names: dict of {'variable_name': expression}
     :return: str expression
     """
+    # replace names with expressions
+    expression = replace_expression_vars(expression, replace_names)
+
     if data_namespace is None:
         data_namespace = {}
     # find name@attribute in expression
@@ -366,12 +399,8 @@ def prepare_expression_load_data(hdf_file: h5py.File, expression: str, hdf_names
     :param use_stored_data: when True, preferentially takes data from data_namespace, rather than loading from file.
     :return: str expression
     """
-    # replace names with expressions
-    for name, replacement in replace_names.items():
-        # TODO: make this more reliable by using either regex or ast
-        expression = expression.replace(name, replacement)
-    # replace parts of the expression
-    expression = prepare_expression(hdf_file, expression, hdf_namespace, data_namespace)  # adds extra_data to data_namespace
+    # replace parts of the expression & add attributes to data_namespace
+    expression = prepare_expression(hdf_file, expression, hdf_namespace, data_namespace, replace_names)
     # find identifier symbols in expression
     identifiers = find_identifiers(expression)
     if use_stored_data:
@@ -419,13 +448,13 @@ def eval_hdf(hdf_file: h5py.File, expression: str, hdf_namespace: dict[str, str]
     if not expression.strip():  # don't evaluate empty strings
         return expression
     # replace names with expressions
-    for name, replacement in replace_names.items():
-        expression = expression.replace(name, replacement)
+    expression = replace_expression_vars(expression, replace_names)
     # if expression is a hdf path, just return the data
     if expression in hdf_file:
         return dataset2data(hdf_file[expression])
     expression = prepare_expression_load_data(hdf_file, expression, hdf_namespace, data_namespace,
                                               replace_names, default, use_stored_data)
+    logger.debug(f"evaluating expression: '{expression}'")
     # evaluate expression within namespace
     safe_eval = asteval.Interpreter(user_symbols=data_namespace, use_numpy=True)
     result = safe_eval(expression, raise_errors=raise_errors)

--- a/src/hdfmap/hdfmap_class.py
+++ b/src/hdfmap/hdfmap_class.py
@@ -127,6 +127,12 @@ class HdfMap:
     - map.eval(h5py.File, 'expression') -> returns output of expression
     - map.format(h5py.File, 'string {name}') -> returns output of str expression
     """
+    __slots__ = (
+        "filename", "all_paths", "groups", "datasets",
+        "classes", "arrays", "values", "metadata", "scannables",
+        "combined", "image_data", "_alternate_names", "_default_image_path",
+        "_local_data", "_use_local_data"
+    )
 
     def __init__(self, file: h5py.File | None = None):
         self.filename = ''
@@ -339,8 +345,16 @@ class HdfMap:
         """
         self._use_local_data = use_data
 
-    def add_named_expression(self, **kwargs):
-        """Add named expression to the local namespace, used in eval"""
+    def add_named_expression(self, **kwargs: str):
+        """
+        Add named expression to the local namespace, used in eval
+
+            self.add_named_expression(my_cmd='(cmd|scan_command)')
+
+        Assigned names are replaced by their expression when evaluating.
+
+        :param kwargs: keyword arguments, each should be a string expression
+        """
         self._alternate_names.update(kwargs)
 
     def add_roi(self, name: str, cen_i: int | str, cen_j: int | str,
@@ -984,12 +998,16 @@ class HdfMap:
         scannables['metadata'] = DataHolder(**metadata)
         return DataHolder(**scannables)
 
-    def eval(self, hdf_file: h5py.File, expression: str, default=DEFAULT, raise_errors: bool = True):
+    def eval(self, hdf_file: h5py.File, expression: str, default=DEFAULT,
+             local_data: dict | None = None, prefer_local: bool | None = None,
+             raise_errors: bool = True):
         """
         Evaluate an expression using the namespace of the hdf file
         :param hdf_file: h5py.File object
         :param expression: str expression to be evaluated
         :param default: returned if varname not in namespace
+        :param local_data: replaces the HdfMap local_data attribute for this file
+        :param prefer_local: uses values in local_data first if available when True
         :param raise_errors: raise exceptions if True, otherwise return str error message as result and log the error
         :return: eval(expression)
         """
@@ -997,19 +1015,23 @@ class HdfMap:
             hdf_file=hdf_file,
             expression=expression,
             hdf_namespace=self.combined,
-            data_namespace=self._local_data,
+            data_namespace=self._local_data if local_data is None else local_data,
             replace_names=self._alternate_names,
             default=default,
-            use_stored_data=self._use_local_data,
+            use_stored_data=self._use_local_data if prefer_local is None else prefer_local,
             raise_errors=raise_errors
         )
 
-    def format_hdf(self, hdf_file: h5py.File, expression: str, default=DEFAULT, raise_errors: bool = True) -> str:
+    def format_hdf(self, hdf_file: h5py.File, expression: str, default=DEFAULT,
+                   local_data: dict | None = None, prefer_local: bool | None = None,
+                   raise_errors: bool = True) -> str:
         """
         Evaluate a formatted string expression using the namespace of the hdf file
         :param hdf_file: h5py.File object
         :param expression: str expression using {name} format specifiers
         :param default: returned if varname not in namespace
+        :param local_data: replaces the HdfMap local_data attribute for this file
+        :param prefer_local: uses values in local_data first if available when True
         :param raise_errors: raise exceptions if True, otherwise return str error message as result and log the error
         :return: eval_hdf(f"expression")
         """
@@ -1017,14 +1039,14 @@ class HdfMap:
             hdf_file=hdf_file,
             expression=expression,
             hdf_namespace=self.combined,
-            data_namespace=self._local_data,
+            data_namespace=self._local_data if local_data is None else local_data,
             replace_names=self._alternate_names,
             default=default,
-            use_stored_data=self._use_local_data,
+            use_stored_data=self._use_local_data if prefer_local is None else prefer_local,
             raise_errors=raise_errors
         )
 
-    def create_interpreter(self, default=DEFAULT):
+    def create_interpreter(self, default=DEFAULT, local_data: dict | None = None, prefer_local: bool | None = None):
         """
         Create an interpreter object for the current file
         The interpreter is a sub-class of asteval.Interpreter that parses expressions for hdfmap eval patters
@@ -1034,15 +1056,19 @@ class HdfMap:
 
             ii = HdfMap.create_interpreter()
             out = ii.eval('expression')
+
+        :param default: returned if varname not in namespace
+        :param local_data: replaces the HdfMap local_data attribute for this file
+        :param prefer_local: uses values in local_data first if available when True
         """
         interpreter = HdfMapInterpreter(
             hdfmap=self,
             replace_names=self._alternate_names,
             default=default,
-            user_symbols=self._local_data,
+            user_symbols=self._local_data if local_data is None else local_data,
             use_numpy=True
         )
-        interpreter.use_stored_data = self._use_local_data
+        interpreter.use_stored_data = self._use_local_data if prefer_local is None else prefer_local
         return interpreter
 
     def create_dataset_summary(self, hdf_file: h5py.File) -> str:

--- a/src/hdfmap/reloader_class.py
+++ b/src/hdfmap/reloader_class.py
@@ -2,6 +2,7 @@
 Reloader class
 """
 
+import os
 import h5py
 import numpy as np
 
@@ -30,6 +31,11 @@ class HdfLoader:
             self.map = create_hdf_map(hdf_filename)
         else:
             self.map = hdf_map
+        self._prefer_local_data = True
+        self._local_data = {
+            'filepath': os.path.abspath(hdf_filename),
+            'filename': os.path.basename(hdf_filename),
+        }
 
     def __repr__(self):
         return f"HdfReloader('{self.filename}')"
@@ -42,13 +48,33 @@ class HdfLoader:
     def __getitem__(self, item):
         return self.get_data(item)
 
+    # def __iter__(self):
+    #     return iter(self.combined)
+
+    def __contains__(self, item):
+        return item in self.map or item in self._local_data
+
     def __call__(self, expression):
         return self.eval(expression)
 
     def _load(self) -> h5py.File:
         return load_hdf(self.filename)
 
-    def get_hdf_path(self, name_or_path: str) -> str or None:
+    def add_local(self, **kwargs):
+        """Add value to the local namespace, used in eval and format"""
+        self._local_data.update(kwargs)
+
+    def live_mode(self, live_mode: bool = True):
+        """
+        Activate the option to reload data from the file each time, rather than from local data
+
+        self.eval('cmd') -> default will load 'cmd' from local storage if available, or from the file
+        self.live_mode() -> self.eval('cmd') will return 'cmd' from the file using hdfmap
+        self.live_mode(False) -> returns to default behavior
+        """
+        self._prefer_local_data = live_mode
+
+    def get_hdf_path(self, name_or_path: str) -> str | None:
         """Return hdf path of object in HdfMap"""
         return self.map.get_path(name_or_path)
 
@@ -125,25 +151,46 @@ class HdfLoader:
         with self._load() as hdf:
             return self.map.create_dataset_summary(hdf)
 
-    def eval(self, expression: str, default=DEFAULT):
+    def eval(self, expression: str, default=DEFAULT, prefer_local: bool | None = None, raise_errors: bool = True):
         """
         Evaluate an expression using the namespace of the hdf file
         :param expression: str expression to be evaluated
         :param default: returned if varname not in namespace
+        :param prefer_local: if True, uses values in local_data first if available
+        :param raise_errors: raise exceptions if True, otherwise return str error message as result and log the error
         :return: eval(expression)
         """
+        prefer_local = self._prefer_local_data if prefer_local is None else prefer_local
+        if prefer_local and expression in self._local_data:
+            return self._local_data[expression]
         with self._load() as hdf:
-            return self.map.eval(hdf, expression, default)
+            return self.map.eval(
+                hdf_file=hdf,
+                expression=expression,
+                default=default,
+                local_data=self._local_data,
+                prefer_local=prefer_local,
+                raise_errors=raise_errors
+            )
 
-    def format(self, expression: str, default=DEFAULT):
+    def format(self, expression: str, default=DEFAULT, prefer_local: bool | None = None, raise_errors: bool = True) -> str:
         """
         Evaluate a formatted string expression using the namespace of the hdf file
         :param expression: str expression using {name} format specifiers
         :param default: returned if varname not in namespace
+        :param prefer_local: if True, uses values in local_data first if available
+        :param raise_errors: raise exceptions if True, otherwise return str error message
         :return: eval_hdf(f"expression")
         """
         with self._load() as hdf:
-            return self.map.format_hdf(hdf, expression, default)
+            return self.map.format_hdf(
+                hdf_file=hdf,
+                expression=expression,
+                default=default,
+                local_data=self._local_data,
+                prefer_local=self._prefer_local_data if prefer_local is None else prefer_local,
+                raise_errors=raise_errors
+            )
 
 
 class NexusLoader(HdfLoader):

--- a/tests/test_eval_functions.py
+++ b/tests/test_eval_functions.py
@@ -8,7 +8,7 @@ from hdfmap.eval_functions import replace_expression_vars, prepare_expression_lo
 
 
 DATA_FOLDER = os.path.join(os.path.dirname(__file__), 'data')
-FILE_HKL = DATA_FOLDER + "/1049598.nxs"  # hkl scan, pilatus
+FILE_HKL = DATA_FOLDER + "/1040323.nxs"  # hkl scan, pilatus
 
 
 def test_replace_expression_vars():
@@ -19,10 +19,16 @@ def test_replace_expression_vars():
 
 
 def test_prepare_expression_load_data():
-    expression = 'idgap@units'
+    expression = 'idgap@units, x*y'
+    repl = {
+        'x': 'a',
+    }
+    hdf_map = {'idgap': '/entry/instrument/insertion_device/gap'}
+    data = {}
     with hdfmap.load_hdf(FILE_HKL) as hdf:
-        new_expr = prepare_expression_load_data(hdf, expression, {}, {}, {})
-    assert new_expr == expression
+        new_expr = prepare_expression_load_data(hdf, expression, hdf_map, data, repl)
+    assert new_expr == "attr__idgap_units, a*y"
+    assert data['attr__idgap_units'] == 'mm'
 
 
 

--- a/tests/test_eval_functions.py
+++ b/tests/test_eval_functions.py
@@ -1,0 +1,28 @@
+"""
+Specific tests for eval_functions.py
+"""
+
+import os
+import hdfmap
+from hdfmap.eval_functions import replace_expression_vars, prepare_expression_load_data
+
+
+DATA_FOLDER = os.path.join(os.path.dirname(__file__), 'data')
+FILE_HKL = DATA_FOLDER + "/1049598.nxs"  # hkl scan, pilatus
+
+
+def test_replace_expression_vars():
+    expression = "a + data_a + max_value"
+    mapping = {"a": "x", "data": 'y', "max_value": "max(x)"}
+    new_expr = replace_expression_vars(expression, mapping)
+    assert new_expr == "x + data_a + max(x)"
+
+
+def test_prepare_expression_load_data():
+    expression = 'idgap@units'
+    with hdfmap.load_hdf(FILE_HKL) as hdf:
+        new_expr = prepare_expression_load_data(hdf, expression, {}, {}, {})
+    assert new_expr == expression
+
+
+

--- a/tests/test_hdfmap_class.py
+++ b/tests/test_hdfmap_class.py
@@ -232,13 +232,18 @@ def test_eval_local_data(hdf_map):
 def test_eval_named_expression(hdf_map):
     hdf_map.add_named_expression(
         norm_data='int(max(sum / Transmission / count_time))',
-        my_path=hdf_map['incident_energy']
+        my_path=hdf_map['incident_energy'],
+        kap="kth"
     )
     with hdfmap.load_hdf(FILE_HKL) as hdf:
         out = hdf_map.eval(hdf, 'norm_data')
         assert out == 6533183, "Expression output gives wrong result"
         out = hdf_map.eval(hdf, 'my_path')
-        assert abs(out - 3.58) < 0.001, "Expression output gives wrong result"
+        assert out == pytest.approx(3.58, 0.001), "Expression output gives wrong result"
+        kap, kappa, kth = hdf_map.eval(hdf, 'mean(kap), mean(kappa), mean(kth)')
+        assert kap == pytest.approx(81.122, 0.001), "kap not correctly replaced"
+        assert kappa == pytest.approx(-134.192, 0.001), "kappa has been changed incorrectly"
+        assert kth == pytest.approx(81.122, 0.001), "kth has been changed incorrectly"
 
 
 def test_roi(hdf_map):

--- a/tests/test_many_files.py
+++ b/tests/test_many_files.py
@@ -1,7 +1,6 @@
 import os
 from time import perf_counter
 import hdfmap
-import hdfmap.hdf_loader
 
 from . import only_dls_file_system
 
@@ -36,7 +35,7 @@ def test_compare_time_for_many_files():
     start = perf_counter()
     output1 = []
     for file in files:
-        with hdfmap.hdf_loader.load_hdf(file) as hdf:
+        with hdfmap.load_hdf(file) as hdf:
             output1.append((
                 hdf['/entry1/scan_command'][()],
                 hdf['/entry1/entry_identifier'][()],
@@ -56,7 +55,7 @@ def test_compare_time_for_many_files():
     start = perf_counter()
     output1 = []
     for file in files:
-        with hdfmap.hdf_loader.load_hdf(file) as hdf:
+        with hdfmap.load_hdf(file) as hdf:
             output1.append((
                 hdf['/entry1/scan_command'][()],
                 hdf['/entry1/entry_identifier'][()],
@@ -72,3 +71,30 @@ def test_compare_time_for_many_files():
     print(f"Performance factor: {((multi_time-single_time2) / single_time2):+.1%} of direct access time")
     # Typically around 40% slower
     assert multi_time < 1.5 * single_time2, "mult-read is much slower than direct read"
+
+
+@only_dls_file_system
+def test_local_data_from_different_files():
+    """Test for issue #42 - multiple instances of HdfLoader contain the same local namespace"""
+    # i21 files 2026 mm23841-1
+    folder = '/dls/science/groups/das/ExampleData/hdfmap_tests/i21/mm23841-1'
+    file1, file2 = [folder + f'/i21-{n}.nxs' for n in [472812, 472811]]
+    m1 = hdfmap.create_nexus_map(file1)
+    m2 = hdfmap.create_nexus_map(file2)
+    assert 'user_input_command' in m1
+    assert 'user_input_command' not in m2
+
+    scan1 = hdfmap.NexusLoader(file1, m1)
+    scan2 = hdfmap.NexusLoader(file2, m1)
+    scan1.add_local(some_data=55)
+    assert scan1.map is scan2.map
+
+    cmd1 = scan1.format('{(cmd|user_input_command|user_command|scan_command)}')
+    cmd2 = scan2.format('{(cmd|user_input_command|user_command|scan_command)}')
+    assert cmd1 != cmd2
+    assert scan1('some_data') == 55
+
+    # setting local data of scan2 also updates scan 1
+    scan2.add_local(some_data=44)
+    assert scan2('some_data') == 44
+    assert scan1('some_data') == 55

--- a/tests/test_reloader_class.py
+++ b/tests/test_reloader_class.py
@@ -1,0 +1,42 @@
+import os
+from hdfmap import HdfLoader, NexusLoader
+
+DATA_FOLDER = os.path.join(os.path.dirname(__file__), 'data')
+FILE_NEW_NEXUS = DATA_FOLDER + '/1040323.nxs'  # new nexus format
+FILE_3D_NEXUS = DATA_FOLDER + '/i06-353130.nxs'  # new nexus format
+
+
+def test_hdf_reloader():
+    scan = HdfLoader(FILE_NEW_NEXUS)
+
+    assert len(scan('h')) == 21
+    cmd = scan.format('{(cmd|scan_command)}')
+    assert cmd == 'scan hkl [0.97, 0.022, 0.112] [0.97, 0.022, 0.132] [0, 0, 0.001] MapperProc pil3_100k 1'
+
+    path = scan.get_hdf_path('TimeSec')
+    assert path == '/entry/measurement/TimeSec'
+
+    h_vals, k_vals, l_vals = scan.get_data('h', 'k', 'l')
+    assert len(h_vals) == len(k_vals) == len(l_vals)
+
+    # Local data
+    scan.add_local(my_data=55, more_data='hello', scan_command='overwriting')
+    assert scan('my_data') == 55
+    assert scan('my_data, more_data') == (55, 'hello')
+    assert 'my_data' in scan
+    assert scan('scan_command') == 'overwriting'
+    assert scan.eval('scan_command', prefer_local=False) == cmd
+
+
+def test_nexus_reloader():
+    scan = NexusLoader(FILE_NEW_NEXUS)
+
+    assert len(scan('axes')) == 21
+    assert len(scan('signal')) == 21
+    assert scan('fast_pixel_direction@units') == 'mm'
+
+    data = scan.get_plot_data()
+    KEYS = {'xlabel', 'ylabel', 'xdata', 'ydata', 'axes_names', 'signal_names', 'axes_data',
+            'signal_data', 'axes_labels', 'signal_labels', 'data', 'title'}
+    assert data.keys() >= KEYS
+


### PR DESCRIPTION
 - add local_data to NexusLoader
 - add name replacer (regex)
 - Fix for #42

## hdfmap_class.py
- add `__slots__`
- add local_data and prefer_local as inputs to eval and format_hdf

## reloader_class.py
- add `__contains__`
- add add_local() and live_mode()
- add _local_data and _prefer_local_data attributes
- use these in eval and format

## eval_functions.py
- replace expression.replace with regex method
- add tests

All tests pass